### PR TITLE
Remove tab space from email signature

### DIFF
--- a/index.html
+++ b/index.html
@@ -77,7 +77,7 @@
                 let encodedSignature = encodeURIComponent(normalisedSignature).replace(/%20/g, " ");
 
                 // Create mail-to link
-                let mailToLink = `mailto:exampleEmail1@email.com,exampleEmail2@email.com?subject=${subjectLine}&&body=${encodeURIComponent(emailMessageBody + encodedSignature)}`;
+                let mailToLink = `mailto:exampleEmail1@email.com,exampleEmail2@email.com?subject=${subjectLine}&body=${encodeURIComponent(emailMessageBody + encodedSignature)}`;
                 console.log(encodedSignature)
 
                 // Open email client with pre-filled email

--- a/index.html
+++ b/index.html
@@ -68,18 +68,17 @@
                 // Get user's signature from text area
                 let signature = document.getElementById("signature").value;
 
-                // Replace spaces with space characters
-                signature = signature.replace(/ /g, " ");
+                // Replace multiple spaces with a single space character, then trim
+                signature = signature.replace(/\s+/g, " ").trim();
 
                 // Normalise signature by replacing special characters
                 let normalisedSignature = normaliseString(signature);
 
-                // Encode signature for use in mail-to link
-                let encodedSignature = encodeURIComponent(normalisedSignature).replace(/%20/g, " ");
+                // Trim trailing whitespace from emailMessageBody
+                let trimmedEmailMessageBody = emailMessageBody.trim();
 
-                // Create mail-to link
-                let mailToLink = `mailto:exampleEmail1@email.com,exampleEmail2@email.com?subject=${subjectLine}&body=${encodeURIComponent(emailMessageBody + encodedSignature)}`;
-                console.log(encodedSignature)
+                // Create encoded mail-to link
+                let mailToLink = `mailto:exampleEmail1@email.com,exampleEmail2@email.com?subject=${subjectLine}&body=${encodeURIComponent(trimmedEmailMessageBody + "\n" + normalisedSignature)}`;
 
                 // Open email client with pre-filled email
                 window.location.href = mailToLink;

--- a/index.html
+++ b/index.html
@@ -7,6 +7,7 @@
         <meta name="color-scheme" content="dark light">
         <meta description="A website built to allow users to send a pre-defined email (which they can preview) to multiple, pre-defined recipients (which they can preview in their email app).">
         <title>Email Sender</title>
+        <link href="./styles.css" rel="stylesheet"/>
         <script>
             let emailMessageBody = `Email message body
 
@@ -86,18 +87,12 @@
         </script>
     </head>
     <body>
-        <div style="width: auto; margin: 0 auto;">
-            <p>Please sign your name and we will write and sign the below email on your behalf.
-                <br>
-            </p>
-            <div>
-                <textarea id="signature" name="signature" placeholder="Type your full name here" style="width: 50%; height: 100px;"></textarea>
-            </div>
-            <input type="button" value="Send Email" onclick="sendEmail()" style="font-size: 30px; width: 50%;">
+        <div>
+            <p>Please sign your name and we will write and sign the below email on your behalf.</p>
+            <textarea class="signature-box" id="signature" name="signature" placeholder="Type your full name here" style="width: 50%; height: 100px;"></textarea>
+            <input class="send-email-button" type="button" value="Send Email" onclick="sendEmail()" style="font-size: 30px; width: 50%;">
             <h3><script>document.write(subjectLine)</script></h3>
-            <p>
-                <script>document.write(emailMessageBody)</script>
-            </p>
+            <p><script>document.write(emailMessageBody)</script></p>
         </div>
     </body>
 </html>

--- a/styles.css
+++ b/styles.css
@@ -1,0 +1,15 @@
+body {
+    font-family: Cascadia Code, sans-serif;
+    text-align: center;
+}
+
+.signature-box {
+    width: 50%;
+    height: 40px;
+}
+
+.send-email-button {
+    font-family: Cascadia Code, sans-serif;
+    font-size: 30px;
+    width: 50%;
+}


### PR DESCRIPTION
Remove tab space from email signature. Example below:

![image](https://github.com/scaulfield7/email-sender/assets/43242833/bcdf219e-5de3-4b49-ac7a-2285f0f7dd75)
