### PR TITLE
Fix inline scripts for email subject and body

### DIFF
--- a/index.html
+++ b/index.html
@@ -15,8 +15,8 @@
             <p>Please sign your name and we will write and sign the below email on your behalf.</p>
             <textarea class="signature-box" id="signature" name="signature" placeholder="Type your full name here"></textarea>
             <input class="send-email-button" type="button" value="Send Email" onclick="sendEmail()">
-            <h3><script>document.write(subjectLine)</script></h3>
-            <p><script>document.write(emailMessageBody)</script></p>
+            <h3 id="subject-line"></h3>
+            <p id="email-message-body"></p>
         </div>
         <footer>
             <h5>Made by Sarah Caulfield</h5>

--- a/script.js
+++ b/script.js
@@ -14,6 +14,9 @@ Sed et nisl nec tortor auctor consequat in nec orci. Phasellus fringilla, lorem 
 
             `;
 
+document.getElementById("subject-line").textContent = subjectLine;
+document.getElementById("email-message-body").textContent = emailMessageBody;
+
 function normaliseString(str) {
     // Define a mapping of accented letters to their non-accented equivalents
     const charMap = {


### PR DESCRIPTION
The subject line and body were not loading correctly following the addition of defer to the script link in the index.html. This was due to them being referenced in in-line scripts later in the index file. Following this PR, getElementById is used to get both to render when the page is loaded.